### PR TITLE
Fix install failures and add graceful model fallbacks

### DIFF
--- a/api.py
+++ b/api.py
@@ -244,11 +244,10 @@ async def convert_panorama(
             )
             print(f"Switched to depth model: {depth_model}")
         except Exception as e:
-            # Clean up the pending job so it doesn't get stuck in the queue
-            del jobs[job_id]
             print(f"Failed to switch depth model to {depth_model}: {e}")
-            raise HTTPException(status_code=500, detail=str(e))
-    
+            print(f"Falling back to current model: {processor.depth_model_name}")
+            depth_model = processor.depth_model_name
+
     # Determine file extension
     suffix = Path(file.filename).suffix if file.filename else '.jpg'
     
@@ -320,11 +319,10 @@ async def convert_video(
             )
             print(f"Switched to depth model: {depth_model}")
         except Exception as e:
-            # Clean up the pending job so it doesn't get stuck in the queue
-            del jobs[job_id]
             print(f"Failed to switch depth model to {depth_model}: {e}")
-            raise HTTPException(status_code=500, detail=str(e))
-            
+            print(f"Falling back to current model: {processor.depth_model_name}")
+            depth_model = processor.depth_model_name
+
     # Save input video
     suffix = Path(file.filename).suffix if file.filename else '.mp4'
     job.input_path = TEMP_DIR / f"{job_id}_input{suffix}"

--- a/install.bat
+++ b/install.bat
@@ -63,6 +63,7 @@ echo [2/4] Installing SPAG-4D Core Requirements...
 
 echo.
 echo [3/4] Installing Optional SHARP Model...
+!PIP! install timm pillow-heif
 !PIP! install --no-deps https://github.com/apple/ml-sharp/archive/refs/heads/main.zip
 
 echo.
@@ -71,7 +72,7 @@ echo [4/5] Installing Optional Depth Anything V3 Model...
 !PIP! install --no-deps --no-build-isolation https://github.com/ByteDance-Seed/depth-anything-3/archive/refs/heads/main.zip
 
 echo.
-echo [5/5] Installing Optional DAP Model...
+echo [5/6] Installing Optional DAP Model...
 !PIP! install einops opencv-python
 if not exist "spag4d\dap_arch\DAP\networks" (
     echo Initializing DAP submodule...
@@ -80,6 +81,15 @@ if not exist "spag4d\dap_arch\DAP\networks" (
         echo Git submodule failed. Cloning DAP manually...
         git clone https://github.com/Insta360-Research-Team/DAP spag4d\dap_arch\DAP
     )
+)
+
+echo.
+echo [6/6] Installing Optional PanDA Model...
+if not exist "spag4d\panda_arch\PanDA\networks" (
+    echo Cloning PanDA model architecture...
+    git clone https://github.com/caozidong/PanDA spag4d\panda_arch\PanDA
+) else (
+    echo PanDA already installed.
 )
 echo ==================================================
 echo   Installation Complete!

--- a/spag4d/core.py
+++ b/spag4d/core.py
@@ -267,7 +267,11 @@ class SPAG4D:
             
             # Ensure model is loaded (no-op if already loaded)
             if self.sharp_refiner is not None:
-                self.sharp_refiner.load_model()
+                try:
+                    self.sharp_refiner.load_model()
+                except (ImportError, Exception) as e:
+                    print(f"SHARP model unavailable ({e}), skipping refinement")
+                    use_sharp = False
             else:
                 use_sharp = False
         


### PR DESCRIPTION
Three issues prevented the app from working after a fresh install:

1. install.bat: SHARP was installed with --no-deps, leaving its required dependency `timm` (and `pillow-heif`) uninstalled. Added explicit pip install of these packages before the SHARP install step.

2. install.bat: PanDA architecture (spag4d/panda_arch/PanDA) was never cloned. The weights were downloaded but the model code was missing, causing WinError 2 on startup. Added a step 6/6 that clones https://github.com/caozidong/PanDA when the directory is absent.

3. api.py + core.py: When a requested depth model (e.g. panda) fails to load, the /api/convert and /api/convert_video endpoints raised HTTP 500 and deleted the pending job. Now they fall back to the currently loaded model and continue processing. Similarly, if SHARP's load_model() raises ImportError (missing timm), the refinement step is skipped gracefully instead of crashing the job.