### PR TITLE
Remove 'fuzzy' parameter from gdown.download

### DIFF
--- a/spag4d/da360_model.py
+++ b/spag4d/da360_model.py
@@ -133,7 +133,6 @@ class DA360Model:
             gdown.download(
                 url=DA360_CONFIG["gdrive_folder"],
                 output=str(DA360_CACHE_DIR),
-                fuzzy=True,
                 quiet=False,
             )
             if cache_path.exists():


### PR DESCRIPTION
Removed the 'fuzzy' parameter from gdown.download call, because of new update on google drive api download parameters.